### PR TITLE
[Refactor] change namespaces and fix quiet mode fixing issues #5, #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ Any errors during execution cause the returned JSPromise to be __rejected__. Err
      ﻿{
      	"checkSuccessful": ... ,
      	"images": [ ... ],
-     	"resultHTML": ... ,
-        "timeOfCheck": {      // dates as milliseconds since 01.01.1970 00:00:00 UTC (UNIX time)
-             "start": Number,
-             "end": Number
-        },
-        "errorsEncountered": [ <Error description> ] 
+     	"display": {
+     	    "diff": "[merged diff-HTML]"
+     	},
+        "start": Date,
+        "end": Date,
+        "errors": [ <Error description> ] 
      }
   ```
 Metadata may contain a varying amount of data, depending on where in the process an error occurred.
@@ -162,15 +162,14 @@ If execution is successful, the Promise will be __resolved__, containing a check
     			}
     		}, ...
     	],
-    	"resultHTML": String, // contains the entire result HTML, 
-    	                      // with images swapped for diff-Images where differences were found;
-    	                      // currently contains text from 'Original' paper
-    	                      
-        "timeOfCheck": {      // dates as milliseconds since 01.01.1970 00:00:00 UTC (UNIX time)
-            "start": Number,
-            "end": Number
-        },
-        "errorsEncountered": [] 
+    	"display": {
+    	    "diff": String // contains the entire result HTML, 
+    	                    // with images swapped for diff-Images where differences were found;
+    	                    // currently contains text from 'Original' paper
+        },             
+        "start": Number,
+        "end": Number,
+        "errors": [] 
     }
  ```
 

--- a/checker.js
+++ b/checker.js
@@ -43,12 +43,12 @@ const regexSplitCuttingImages = /<img src="data:image\/png;base64,.*" \/>/g;
 var metadata = {
 	checkSuccessful: true,
 	images: [],
-	resultHTML: null,
-	timeOfCheck : {
-		start: null,
-		end: null
+	display: {
+		diff: null
 	},
-	errorsEncountered: []
+	start: null,
+	end: null,
+	errors: []
 };
 
 /**
@@ -64,21 +64,21 @@ var metadata = {
 function stringifyHTMLandCompare(originalHTMLPaperPath, reproducedHTMLPaperPath, quiet, checkStart) {
 
 	if (quiet) {
-		debugGeneral = debugSlice = debugCompare = debugReassemble = debugERROR = null;
+		debugGeneral.enabled = debugSlice.enabled = debugCompare.enabled = debugReassemble.enabled = debugERROR.enabled = false;
 	}
 	metadata = {
 		checkSuccessful: true,
 		images: [],
-		resultHTML: null,
-		timeOfCheck : {
-			start: null,
-			end: null
+		display: {
+			diff: null
 		},
-		errorsEncountered: []
+		start: null,
+		end: null,
+		errors: []
 	};
 
 	// set start date in check metadata
-	metadata.timeOfCheck.start = checkStart;
+	metadata.start = checkStart;
 
 	// if tmp directory for erc-checker does not exist already, create it
 	try {
@@ -166,7 +166,7 @@ function readFileSync(paperPath) {
 		}
 		catch (e) {
 			debugERROR("Error: Could not read file %s.".red, paperPath);
-			metadata.errorsEncountered.push(e);
+			metadata.errors.push(e);
 			reject(e);
 		}
 	})
@@ -229,7 +229,7 @@ function sliceImagesOutOfHTMLStringsAndCreateBuffers(readFilesArray) {
 			}
 			catch (e) {
 				debugERROR("Failed to create Buffer for at least one base64 encoded image.");
-				metadata.errorsEncountered.push(e);
+				metadata.errors.push(e);
 				reject(e);
 			}
 
@@ -301,7 +301,7 @@ function prepareImagesForComparison(twoDimensionalArrayOfBuffers) {
 					}
 					catch (e) {
 						debugERROR("Failed to get size on image %s. Buffer may be broken.".red, index);
-						metadata.errorsEncountered.push(e);
+						metadata.errors.push(e);
 						reject(e);
 					}
 
@@ -390,14 +390,14 @@ function resizeImageIfNecessary(originalImageBuffer, reproducedImageBuffer, dime
 									})
 									.catch(e => {
 										debugERROR("Failure resizing Reproduced image No.%s.".red, index);
-										metadata.errorsEncountered.push(e);
+										metadata.errors.push(e);
 										resultHandler(false, e);
 									});
 							}
 						})
 						.catch(e => {
 							debugERROR("Failure resizing Original image No.%s.".red, index);
-							metadata.errorsEncountered.push(e);
+							metadata.errors.push(e);
 							resultHandler(false, e)
 						});
 				}
@@ -414,7 +414,7 @@ function resizeImageIfNecessary(originalImageBuffer, reproducedImageBuffer, dime
 							})
 							.catch(e => {
 								debugERROR("Failure resizing Reproduced image No.%s.".red, index);
-								metadata.errorsEncountered.push(e);
+								metadata.errors.push(e);
 								resultHandler(false, e);
 							});
 					}
@@ -486,7 +486,7 @@ function runBlinkDiff(images) {
 						function (err, result) {
 							if (err) {
 								debugERROR("Error comparing images with index %s.".red, index);
-								metadata.errorsEncountered.push(err);
+								metadata.errors.push(err);
 								reject([new Error("Error reading file", err), tmpBlinkOutputPath]);
 							}
 
@@ -542,7 +542,7 @@ function reassembleDiffHTML (diffImageBufferArray, textChunkArray) {
 			reassembledDiffHTMLString += textChunkArray.pop();
 			debugReassemble("Reassembly done.".green);
 
-			metadata.resultHTML = reassembledDiffHTMLString;
+			metadata.display.diff = reassembledDiffHTMLString;
 			resolve(metadata);
 
 		}

--- a/test/indexDiscriminator.js
+++ b/test/indexDiscriminator.js
@@ -49,7 +49,7 @@ describe('Testing erc-checker', function () {
 					expect(resolve).to.equal(undefined)
 				},
 				function (rejectMetadata) {
-					expect(rejectMetadata.errorsEncountered[0]).to.not.equal(0);
+					expect(rejectMetadata.errors[0]).to.not.equal(0);
 				})
 		});
 
@@ -64,7 +64,7 @@ describe('Testing erc-checker', function () {
 					expect(resolve).to.equal(undefined);
 				},
 				function (rejectMetadata) {
-					expect(rejectMetadata.errorsEncountered[0]).to.not.equal(0);
+					expect(rejectMetadata.errors[0]).to.not.equal(0);
 				})
 		});
 
@@ -76,7 +76,7 @@ describe('Testing erc-checker', function () {
 
 			checker(config)
 				.then(function (resolve) {
-						if ( resolve.checkSuccessful == true && resolve.errorsEncountered[0] == null) {done()}
+						if ( resolve.checkSuccessful == true && resolve.errors[0] == null) {done()}
 						else { done(new Error ("Failed to handle equal papers")) }
 				},
 				function (reject) {

--- a/test/testModuleUsage.js
+++ b/test/testModuleUsage.js
@@ -74,7 +74,7 @@ describe('Using ERC-Checker as node-module', function () {
 				.then(function (resolve) {
 					expect(resolve).to.equal(null);
 				}, function (reason) {
-					expect(reason.errorsEncountered[0]).to.not.equal(null);
+					expect(reason.errors[0]).to.not.equal(null);
 				});
 
 			config.pathToOriginalHTML = testStringF;
@@ -83,7 +83,7 @@ describe('Using ERC-Checker as node-module', function () {
 				.then(function (resolve) {
 					expect(resolve).to.equal(null);
 				}, function (reason) {
-					expect(reason.errorsEncountered[0]).to.not.equal(null);
+					expect(reason.errors[0]).to.not.equal(null);
 				});
 
 			config.pathToReproducedHTML = testStringF;
@@ -91,7 +91,7 @@ describe('Using ERC-Checker as node-module', function () {
 				.then(function (resolve) {
 					expect(resolve).to.equal(null);
 				}, function (reason) {
-					expect(reason.errorsEncountered[0]).to.not.equal(null);
+					expect(reason.errors[0]).to.not.equal(null);
 				});
 		});
 
@@ -104,7 +104,7 @@ describe('Using ERC-Checker as node-module', function () {
 						expect(resolve).to.equal(null)
 					},
 					function (rejectMetadata) {
-						expect(rejectMetadata.errorsEncountered[0]).to.not.equal(null);
+						expect(rejectMetadata.errors[0]).to.not.equal(null);
 					});
 
 			config.pathToOriginalHTML = testStringC;
@@ -114,7 +114,7 @@ describe('Using ERC-Checker as node-module', function () {
 						expect(resolve).to.equal(null)
 					},
 					function (rejectMetadata) {
-						expect(rejectMetadata.errorsEncountered[0]).to.not.equal(null);
+						expect(rejectMetadata.errors[0]).to.not.equal(null);
 					});
 		})
 	});
@@ -136,7 +136,7 @@ describe('Using ERC-Checker as node-module', function () {
 							assert.isDefined(metadata, "No resolve metadata");
 
 							assert.isTrue(metadata.checkSuccessful, "check should not have found differences, yet it did");
-							assert.isUndefined(metadata.errorsEncountered[0], "There should have been no errors, instead: " + JSON.stringify(metadata.errorsEncountered));
+							assert.isUndefined(metadata.errors[0], "There should have been no errors, instead: " + JSON.stringify(metadata.errors));
 
 						}
 					)
@@ -165,10 +165,10 @@ describe('Using ERC-Checker as node-module', function () {
 
 							assert.isFalse(metadata.checkSuccessful, "Paper contains differences, check should find them and be unsuccessful.".red);
 
-							assert.isUndefined(metadata.errorsEncountered[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errorsEncountered[0]+" and "+metadata.errorsEncountered[1]+" and "+metadata.errorsEncountered[2]);
-							assert.strictEqual(metadata.errorsEncountered.length, 0, "Encountered Errors should be empty, but contained "+metadata.errorsEncountered.length+" errors.");
+							assert.isUndefined(metadata.errors[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errors[0]+" and "+metadata.errors[1]+" and "+metadata.errors[2]);
+							assert.strictEqual(metadata.errors.length, 0, "Encountered Errors should be empty, but contained "+metadata.errors.length+" errors.");
 							assert.strictEqual(metadata.images.length, 2, "Paper contains 9 images, but only "+metadata.images.length+" were compared / featured in result object.");
-							assert.isString(metadata.resultHTML, "Resulting Diff HTML is not returned correctly (not a String)");
+							assert.isString(metadata.display.diff, "Resulting Diff HTML is not returned correctly (not a String)");
 
 							assert.strictEqual(metadata.images[0].compareResults.differences, 0, "Image #1 is equal in both test papers, but differences were found.");
 							assert.notStrictEqual(metadata.images[1].compareResults.differences, 0, "Images #2 in test papers are different, yet no differences were found.");
@@ -204,10 +204,10 @@ describe('Using ERC-Checker as node-module', function () {
 
 							assert.isFalse(metadata.checkSuccessful, "Paper contains differences, check should find them and be unsuccessful.".red);
 
-							assert.isUndefined(metadata.errorsEncountered[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errorsEncountered[0]);
-							assert.strictEqual(metadata.errorsEncountered.length, 0, "Encountered Errors should be empty, but contained "+metadata.errorsEncountered.length+" errors.");
+							assert.isUndefined(metadata.errors[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errors[0]);
+							assert.strictEqual(metadata.errors.length, 0, "Encountered Errors should be empty, but contained "+metadata.errors.length+" errors.");
 							assert.strictEqual(metadata.images.length, 9, "Paper contains 9 images, but only "+metadata.images.length+" were compared / featured in result object.");
-							assert.isString(metadata.resultHTML, "Resulting Diff HTML is not returned correctly (not a String)");
+							assert.isString(metadata.display.diff, "Resulting Diff HTML is not returned correctly (not a String)");
 						},
 						function (reason) {
 							done(new Error(reason));
@@ -246,10 +246,10 @@ describe('Using ERC-Checker as node-module', function () {
 
 							assert.isFalse(metadata.checkSuccessful, "Paper contains differences, check should find them and be unsuccessful.".red);
 
-							assert.isUndefined(metadata.errorsEncountered[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errorsEncountered[0]);
-							assert.strictEqual(metadata.errorsEncountered.length, 0, "Encountered Errors should be empty, but contained "+metadata.errorsEncountered.length+" errors.");
+							assert.isUndefined(metadata.errors[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errors[0]);
+							assert.strictEqual(metadata.errors.length, 0, "Encountered Errors should be empty, but contained "+metadata.errors.length+" errors.");
 							assert.strictEqual(metadata.images.length, 9, "Paper contains 9 images, but only "+metadata.images.length+" were compared / featured in result object.");
-							assert.isString(metadata.resultHTML, "Resulting Diff HTML is not returned correctly (not a String)");
+							assert.isString(metadata.display.diff, "Resulting Diff HTML is not returned correctly (not a String)");
 						}
 					)
 					.then(
@@ -293,7 +293,7 @@ describe('Using ERC-Checker as node-module', function () {
 							errorReadingOutputFile  = e;
 						}
 
-						assert.strictEqual(resultMetadata.errorsEncountered.length, 0, "Check should not have produced Errors, yet it did: "+ resultMetadata.errorsEncountered);
+						assert.strictEqual(resultMetadata.errors.length, 0, "Check should not have produced Errors, yet it did: "+ resultMetadata.errors);
 
 						assert.isTrue(outputFileCreated, "Error: Output file was not created or could not be read: " + errorReadingOutputFile);
 
@@ -321,10 +321,10 @@ describe('Using ERC-Checker as node-module', function () {
 					let metadata = resultMetadata;
 					assert.isFalse(metadata.checkSuccessful, "Paper contains differences, check should find them and be unsuccessful.".red);
 
-					assert.isUndefined(metadata.errorsEncountered[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errorsEncountered[0]+" and "+metadata.errorsEncountered[1]+" and "+metadata.errorsEncountered[2]);
-					assert.strictEqual(metadata.errorsEncountered.length, 0, "Encountered Errors should be empty, but contained "+metadata.errorsEncountered.length+" errors.");
+					assert.isUndefined(metadata.errors[0], "Encountered Errors should be empty, but contained  at least: "+metadata.errors[0]+" and "+metadata.errors[1]+" and "+metadata.errors[2]);
+					assert.strictEqual(metadata.errors.length, 0, "Encountered Errors should be empty, but contained "+metadata.errors.length+" errors.");
 					assert.strictEqual(metadata.images.length, 2, "Paper contains 9 images, but only "+metadata.images.length+" were compared / featured in result object.");
-					assert.isString(metadata.resultHTML, "Resulting Diff HTML is not returned correctly (not a String)");
+					assert.isString(metadata.display.diff, "Resulting Diff HTML is not returned correctly (not a String)");
 
 					assert.strictEqual(metadata.images[0].compareResults.differences, 0, "Image #1 is equal in both test papers, but differences were found.");
 					assert.notStrictEqual(metadata.images[1].compareResults.differences, 0, "Images #2 in test papers are different, yet no differences were found.");


### PR DESCRIPTION
Latest commit to sort out Issues #5 #6 : 

Fix quiet mode by using `debug.enabled` property, instead of overriding `debug`-objects.

Change namespaces for several metadata properties throughout checker:
`errorsEncountered: [ ]`  -->  `errors: [ ]`
`timeOfCheck: { ... }`  -->  `start: Date,   end: Date, ...`
`resultHTML`  -->  `display:  { diff: String }`